### PR TITLE
Possible gpcc output binary bug

### DIFF
--- a/gpcc.py
+++ b/gpcc.py
@@ -30,7 +30,9 @@ def gpcc_decode(bin_dir, rec_dir, show=False):
     subp=subprocess.Popen(rootdir+'/tmc3'+ 
                             ' --mode=1'+ 
                             ' --compressedStreamPath='+bin_dir+ 
-                            ' --reconstructedDataPath='+rec_dir, 
+                            ' --reconstructedDataPath='+rec_dir+
+                            ' --outputBinaryPly=0'
+                          ,
                             shell=True, stdout=subprocess.PIPE)
     c=subp.stdout.readline()
     while c:


### PR DESCRIPTION
run the test script.
```sh
sudo chmod 777 tmc3 pc_error_d
python coder.py --filedir='longdress_vox10_1300.ply' --ckptdir='ckpts/r3_0.10bpp.pth'
python test.py --filedir='longdress_vox10_1300.ply' 
```

The latest version of tmc downloaded from https://github.com/MPEGGroup/mpeg-pcc-tmc13 outputs binary format ply instead of ascii format ply by default, but our program can only handle ascii ply,  resulting in running errors. Set ```--outputBinaryPly=0``` to solve.

```python
Traceback (most recent call last):
  File "/home/kaiwang/Project/PCGCv2/test.py", line 113, in <module>
    all_results = test(args.filedir, ckptdir_list, args.outdir, args.resultdir, res=args.res)
  File "/home/kaiwang/Project/PCGCv2/test.py", line 52, in test
    x_dec = coder.decode(postfix=postfix_idx, rho=rho)
  File "/home/kaiwang/.conda/envs/DLPT/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 28, in decorate_context
    return func(*args, **kwargs)
  File "/home/kaiwang/Project/PCGCv2/coder.py", line 96, in decode
    y_C = self.coordinate_coder.decode(postfix=postfix)
  File "/home/kaiwang/Project/PCGCv2/coder.py", line 33, in decode
    coords = read_ply_ascii_geo(self.ply_filename)
  File "/home/kaiwang/Project/PCGCv2/data_utils.py", line 22, in read_ply_ascii_geo
    for i, line in enumerate(files):
  File "/home/kaiwang/.conda/envs/DLPT/lib/python3.8/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 200: invalid start byte
```

read_ply_ascii_geo
```python
def read_ply_ascii_geo(filedir):
    files = open(filedir)
    data = []
    for i, line in enumerate(files):
        wordslist = line.split(' ')
        try:
            line_values = []
            for i, v in enumerate(wordslist):
                if v == '\n': continue
                line_values.append(float(v))
        except ValueError: continue
        data.append(line_values)
    data = np.array(data)
    coords = data[:,0:3].astype('int')

    return coords
```